### PR TITLE
TactileWaves Version 1.0.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,12 +15,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 get back to 2 sided versions
 - FormantExtractor now takes number of formants to extract as a constructor argument (before it was 
 hardcoded to 3, now it will default to 4 if not specified)
+- FormantExtractor now ony returns valid formants (frequency > 90 Hz, bandwidth < 400 Hz)
 - index.html was changed to add a few small tweaks to the web page
 
 ### Fixed 
 - MFCC returning NaN's if filter bank was setup with too many filters, or if the minimum frequency 
 is set too low.
 - fixed an error in Filters recursive filter calculation
+- fixed an error in FFT's Power spectrum calculation - previously was dividing by N instead of N^2
 
 ## 1.0.0 - 2018-03-09
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,27 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## 1.0.1 - 2018-03-22 
+### Added
+- A-weighting filter to Filter
+- JavaDoc comments to Utilities class
+- a changelog
+
+### Changed
+- Power and Magnitude calculations in FFT to single sided form, divide by 2 and mirror the array to 
+get back to 2 sided versions
+- FormantExtractor now takes number of formants to extract as a constructor argument (before it was 
+hardcoded to 3, now it will default to 4 if not specified)
+- index.html was changed to add a few small tweaks to the web page
+
+### Fixed 
+- MFCC returning NaN's if filter bank was setup with too many filters, or if the minimum frequency 
+is set too low.
+- fixed an error in Filters recursive filter calculation
+
+## 1.0.0 - 2018-03-09
+### Added
+- TactileWaves Package - the core toolbox dsp library and audio engine

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Tactile Waves Web Page</title>
+    <title>Tactile Waves</title>
   	<meta charset="utf-8">
   	<meta name="viewport" content="width=device-width, initial-scale=1">
   	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
@@ -247,7 +247,7 @@
 <div id="start" class="container-fluid text-left">
 	<h2>Getting Started with Tactile Waves</h2>
 	<hr>
-	<p>Tactile Waves provides a system for handling audio recording, buffering, windowing and processing in a few easy to use objects within the tactilewaves.dsp package.</p>
+	<p>Tactile Waves provides a system for handling audio recording, buffering, windowing and processing in a few easy to use objects within the <code>tactilewaves.dsp</code> package.</p>
     <h3>WaveManager</h3>
 	<p>The <code>WaveManager</code> object represents the core of Tactile Waves' audio engine. It reads audio samples from a <code>WaveInputStream</code>, and generates a <code>WaveFrame</code> for each frame of audio acquired. Each <code>WaveFrame</code> is passed through a chain of <code>WaveProcessor</code> objects that perform some useful processing on the frame, and optionally store extracted audio features in the frame's feature set. Processed frames are then sent to any <code>WaveListener</code> objects that have been added to the <code>WaveManager</code>. These listeners can be used to trigger UI updates, or send extracted audio features to sensory substitution hardware.</p>
     <h3>WaveInputStream</h3>
@@ -319,33 +319,33 @@
 	<h2>CONTACT</h2>
 	<hr>
   	<div class="row">
-    		<div class="col-sm-5">
-      			<p>Drop me a note:</p>
-      			<p><span class="glyphicon glyphicon-map-marker"></span> Fort Collins, US</p>
-      			<p><span class="glyphicon glyphicon-envelope"></span> funkatronicsmail@gmail.com</p>
-    		</div>
-    		<div class="col-sm-7 slideanim">
-        		<form action="https://formspree.io/funkatronicsmail@gmail.com" method="POST">
-					<input type="hidden" name="_subject" value="New Contact from Tactile Waves Web Page" />
-					<input type="hidden" name="_format" value="plain" />
-					<input type="hidden" name="_next" value="//Funkatronics.github.io/TactileWaves/web/thankyou.html" />
-      				<div class="row">
-        				<div class="col-sm-6 form-group">
-      						<input class="form-control" name="name" placeholder="Name" type="text" required autofocus />
-        				</div>
-        				<div class="col-sm-6 form-group">
-          					<input class="form-control" name="email" placeholder="Email" type="email" required />
-        				</div>
-      				</div>
-					<textarea class="form-control" name="comments" placeholder="Comment" rows="5" required ></textarea>
-					<br>
-      				<div class="row">
-        				<div class="col-sm-12 form-group">
-                        	<input class="btn btn-default pull-right" type="submit" value="Send">
-        				</div>
-      				</div>
-            		</form>
-    		</div>
+		<div class="col-sm-5">
+			<p>Drop me a note:</p>
+			<p><span class="glyphicon glyphicon-map-marker"></span> Fort Collins, US</p>
+      		<p><span class="glyphicon glyphicon-envelope"></span> funkatronicsmail@gmail.com</p>
+		</div>
+		<div class="col-sm-7 slideanim">
+			<form action="https://formspree.io/funkatronicsmail@gmail.com" method="POST">
+				<input type="hidden" name="_subject" value="New Contact from Tactile Waves Web Page" />
+				<input type="hidden" name="_format" value="plain" />
+				<input type="hidden" name="_next" value="//Funkatronics.github.io/TactileWaves/web/thankyou.html" />
+				<div class="row">
+					<div class="col-sm-6 form-group">
+						<input class="form-control" name="name" placeholder="Name" type="text" required autofocus />
+					</div>
+					<div class="col-sm-6 form-group">
+						<input class="form-control" name="email" placeholder="Email" type="email" required />
+					</div>
+				</div>
+				<textarea class="form-control" name="comments" placeholder="Comment" rows="5" required ></textarea>
+				<br>
+				<div class="row">
+					<div class="col-sm-12 form-group">
+						<input class="btn btn-default pull-right" type="submit" value="Send">
+					</div>
+				</div>
+			</form>
+		</div>
   	</div>
 </div>
 

--- a/src/main/java/funkatronics/code/tactilewaves/dsp/toolbox/FFT.java
+++ b/src/main/java/funkatronics/code/tactilewaves/dsp/toolbox/FFT.java
@@ -56,6 +56,8 @@
 
 package funkatronics.code.tactilewaves.dsp.toolbox;
 
+import java.util.Arrays;
+
 import funkatronics.code.tactilewaves.dsp.utilities.Complex;
 
 /**
@@ -187,9 +189,11 @@ public class FFT {
         // FFT
         fft(X, Y);
         for(int i = 0; i < N; i++){
-            X[i] = (X[i]*X[i] + Y[i]*Y[i])/N;
+            X[i] = (X[i]*X[i] + Y[i]*Y[i])/(N*N);
+			if(i > 0) X[i] *= 2;
         }
-        return X;
+        return Arrays.copyOf(X, N/2);
+		//return X;
     }
 
     /**
@@ -209,9 +213,11 @@ public class FFT {
         // FFT
         fft(X, Y);
         for(int i = 0; i < N; i++){
-            X[i] = (X[i]*X[i] + Y[i]*Y[i])/N;
+            X[i] = (X[i]*X[i] + Y[i]*Y[i])/(N*N);
+			if(i > 0) X[i] *= 2;
         }
-        return X;
+		return Arrays.copyOf(X, N/2);
+		//return X;
     }
 
     /**
@@ -231,9 +237,11 @@ public class FFT {
         // FFT
         fft(X, Y);
         for(int i = 0; i < N; i++){
-            X[i] = (float) Math.sqrt(X[i]*X[i] + Y[i]*Y[i])/N;
+            X[i] = (float)Math.sqrt(X[i]*X[i] + Y[i]*Y[i])/N;
+            if(i > 0) X[i] *= 2;
         }
-        return X;
+		return Arrays.copyOf(X, N/2);
+		//return X;
     }
 
     /**
@@ -254,8 +262,10 @@ public class FFT {
         fft(X, Y);
         for(int i = 0; i < N; i++){
             X[i] = Math.sqrt(X[i]*X[i] + Y[i]*Y[i])/N;
+			if(i > 0) X[i] *= 2;
         }
-        return X;
+		return Arrays.copyOf(X, N/2);
+		//return X;
     }
 
     /**

--- a/src/main/java/funkatronics/code/tactilewaves/dsp/toolbox/Filter.java
+++ b/src/main/java/funkatronics/code/tactilewaves/dsp/toolbox/Filter.java
@@ -373,7 +373,7 @@ public class Filter {
             for (int k = 0; k < a.length; k++)
                 if(k <= n) y[n] += a[k] * x[n - k];
             for (int k = 1; k < b.length; k++)
-                if(k <= n) y[n] += b[k] * y[n - k];
+                if(k <= n) y[n] -= b[k] * y[n - k];
         }
         return y;
     }
@@ -395,7 +395,7 @@ public class Filter {
             for (int k = 0; k < a.length; k++)
                 if(k <= n) y[n] += a[k] * x[n - k];
             for (int k = 1; k < b.length; k++)
-                if(k <= n) y[n] += b[k] * y[n - k];
+                if(k <= n) y[n] -= b[k] * y[n - k];
         }
         return y;
     }
@@ -417,33 +417,63 @@ public class Filter {
             for (int k = 0; k < a.length; k++)
                 if(k <= n) y[n] += a[k] * x[n - k];
             for (int k = 1; k < b.length; k++)
-                if(k <= n) y[n] += b[k] * y[n - k];
+                if(k <= n) y[n] -= b[k] * y[n - k];
         }
         return y;
     }
 
+	/**
+	 * Apply an A-Weighting Filter to a signal/data series
+	 *
+	 * @param x the signal or data series to be filtered
+	 *
+	 * @return the filtered data
+	 */
+	public static float[] aWeighting(float[] x) {
+		double[] a = {1.0, -4.0195761811158341, 6.189406442920701, -4.4531989035441244,
+				1.4208429496218802,	-0.1418254738303048, 0.0043511772334950813};
+		double[] b = {0.25574112520425751, -0.51148225040851258, -0.25574112520426606,
+				1.022964500817038, -0.25574112520426173, -0.51148225040851303, 0.25574112520425674};
+		return Filter.filter(b, a, x);
+	}
+
+	/**
+	 * Apply an A-Weighting Filter to a signal/data series
+	 *
+	 * @param x the signal or data series to be filtered
+	 *
+	 * @return the filtered data
+	 */
+	public static double[] aWeighting(double[] x) {
+		double[] a = {1.0, -4.0195761811158341, 6.189406442920701, -4.4531989035441244,
+				1.4208429496218802,	-0.1418254738303048, 0.0043511772334950813};
+		double[] b = {0.25574112520425751, -0.51148225040851258, -0.25574112520426606,
+				1.022964500817038, -0.25574112520426173, -0.51148225040851303, 0.25574112520425674};
+		return Filter.filter(b, a, x);
+	}
+
     /**
-     * Apply a Pre-Emphasis Filter toa signal/data series
+     * Apply a Pre-Emphasis Filter to a signal/data series
      *
      * @param x the signal or data series to be filtered
      *
      * @return the filtered data
      */
     public static float[] preEmphasis(float[] x) {
-        double[] a = {1.0, -0.63};
+        double[] a = {1.0, 0.63};
         double[] b = {1.0};
         return Filter.filter(b, a, x);
     }
 
     /**
-     * Apply a Pre-Emphasis Filter toa signal/data series
+     * Apply a Pre-Emphasis Filter to a signal/data series
      *
      * @param x the signal or data series to be filtered
      *
      * @return the filtered data
      */
     public static double[] preEmphasis(double[] x) {
-        double[] a = {1.0, -0.63};
+        double[] a = {1.0, 0.63};
         double[] b = {1.0};
         return Filter.filter(b, a, x);
     }

--- a/src/main/java/funkatronics/code/tactilewaves/dsp/toolbox/MFCC.java
+++ b/src/main/java/funkatronics/code/tactilewaves/dsp/toolbox/MFCC.java
@@ -141,7 +141,7 @@ public class MFCC {
             for(int k = f[m-1]; k <= f[m]; k++) fb[m-1] += X[k] * (k - f[m-1])/(f[m] - f[m-1]);
             for(int k = f[m]; k <= f[m+1]; k++) fb[m-1] += X[k] * (f[m+1] - k)/(f[m+1] - f[m]);
             //fb[m-1] = 20.0 * Math.log10(fb[m-1]);
-            if(fb[m-1] < 1e-5) fb[m-1] = 1e-5;
+            if(fb[m-1] < 1e-5 || fb[m-1] != fb[m-1]) fb[m-1] = 1e-5;
             fb[m-1] = Math.log(fb[m-1]);
         }
 
@@ -194,7 +194,7 @@ public class MFCC {
         // Get Periodogram
         double[] X = FFT.PowerSpectrum(x);
 
-        // Initialize filter bank
+        // Initialize filters
         int[] f = initFilterBanks(Nfilt, minF, maxF, X.length, Fs);
 
         // Compute filter bank
@@ -203,7 +203,7 @@ public class MFCC {
             for(int k = f[m-1]; k <= f[m]; k++) fb[m-1] += X[k] * (k - f[m-1])/(f[m] - f[m-1]);
             for(int k = f[m]; k <= f[m+1]; k++) fb[m-1] += X[k] * (f[m+1] - k)/(f[m+1] - f[m]);
             //fb[m-1] = 20.0 * Math.log10(fb[m-1]);
-            if(fb[m-1] < 1e-5) fb[m-1] = 1e-5;
+            if(fb[m-1] < 1e-5 || fb[m-1] != fb[m-1]) fb[m-1] = 1e-5;
             fb[m-1] = Math.log(fb[m-1]);
         }
 

--- a/src/main/java/funkatronics/code/tactilewaves/dsp/utilities/Utilities.java
+++ b/src/main/java/funkatronics/code/tactilewaves/dsp/utilities/Utilities.java
@@ -60,6 +60,10 @@ import java.util.Arrays;
 
 /**
  * Class that contains several utility methods such as sorting or averaging arrays
+ * <p>
+ *     These methods will more than likely be refactored into more specific classes in the near
+ *     future.
+ * </p>
  *
  * @author Marco Martinez
  */
@@ -71,38 +75,77 @@ public class Utilities {
     // Do not allow instantiation
     private Utilities(){}
 
-    public static double[] ansiBands(int N, int chan) {
-        double[] fi = new double[chan];
+	/**
+	 * Returns the center frequencies of the Octave-Band and Fractional-Octave-Band filter
+	 * frequencies according to the
+	 * <a href="https://law.resource.org/pub/us/cfr/ibr/002/ansi.s1.11.2004.pdf">
+	 *     ANSI Specification
+	 * </a>.
+	 *
+	 * @param N the fractional octave band to compute, i.e. 3 for 1/3 octave bands
+	 * @param bands the number of filter bands to compute
+	 *
+	 * @return an array containing the center frequency of each 1/N octave band
+	 */
+    public static double[] ansiBands(int N, int bands) {
+        double[] fi = new double[bands];
         double b = (double) 1/N;
-        for(int j = 0; j < chan; j++) {
-            int i = j - chan/3;
+        for(int j = 0; j < bands; j++) {
+            int i = j - bands/3;
             if(N%2 == 0) fi[j] = 1000.0 * Math.pow(2.0, ((i+1)*b)/2.0);
             else fi[j] = 1000.0 * Math.pow(2.0, i*b);
         }
         return fi;
     }
 
-    public static double[] ansiBandLimits(int N, int chan) {
-        chan++;
-        double[] fi = new double[chan];
+	/**
+	 * Returns the band limit frequencies of the Octave-Band and Fractional-Octave-Band filter
+	 * frequencies according to the
+	 * <a href="https://law.resource.org/pub/us/cfr/ibr/002/ansi.s1.11.2004.pdf">
+	 *     ANSI Specification
+	 * </a>.
+	 *
+	 * @param N the fractional octave band to compute, i.e. 3 for 1/3 octave bands
+	 * @param bands the number of filter bands to compute
+	 *
+	 * @return an array of length bands+1 containing the upper and lower band limit frequency of
+	 * 		   each 1/N octave band
+	 */
+    public static double[] ansiBandLimits(int N, int bands) {
+        bands++;
+        double[] fi = new double[bands];
         double b = (double) 1/N;
-        for(int j = 0; j < chan; j++) {
-            int i = j - chan/3;
+        for(int j = 0; j < bands; j++) {
+            int i = j - bands/3;
             if(N%2 == 0) fi[j] = 710.0 * Math.pow(2.0, ((i+1)*b)/2.0);
             else fi[j] = 710.0 * Math.pow(2.0, i*b);
         }
         return fi;
     }
 
-    public static float max(float[] aData) {
+	/**
+	 * Find the maximum of an array
+	 *
+	 * @param data the array
+	 *
+	 * @return the maximum value in the array
+	 */
+	public static float max(float[] data) {
         float max = -Float.MAX_VALUE;
-        for (float value : aData) {
+        for (float value : data) {
             if (value > max) max = value;
         }
         return max;
     }
 
-    public static int maxLoc(float[] data) {
+	/**
+	 * Find the index location of the maximum value of an array
+	 *
+	 * @param data the array
+	 *
+	 * @return the index location of the maximum value in the array
+	 */
+	public static int maxLoc(float[] data) {
         float max = -Float.MAX_VALUE;
         int maxLoc = 0;
         for(int i = 0; i < data.length; i++) {
@@ -114,12 +157,27 @@ public class Utilities {
         return maxLoc;
     }
 
-    public static float avgArray(float[] data) {
+	/**
+	 * Find the average of an array
+	 *
+	 * @param data the array
+	 *
+	 * @return the average of all the values in the array
+	 */
+	public static float avgArray(float[] data) {
         float sum = 0;
         for (float value : data) sum += value;
         return sum/data.length;
     }
 
+	/**
+	 * Find the N highest peaks in an array
+	 *
+	 * @param data the array
+	 * @param numPeaks the number of peaks to find
+	 *
+	 * @return the highest peaks in the array, in descending order
+	 */
     public static int[] findHighestPeaks(float[] data, int numPeaks){
         int peaks[] = new int[numPeaks];
         Arrays.fill(peaks, -1);
@@ -139,6 +197,14 @@ public class Utilities {
         return peaks;
     }
 
+	/**
+	 * Find the N lowest peaks in an array
+	 *
+	 * @param data the array
+	 * @param numPeaks the number of peaks to find
+	 *
+	 * @return the lowest peaks in the array, in ascending order
+	 */
     public static int[] findLowestPeaks(float[] data, int numPeaks){
         int peaks[] = new int[numPeaks];
         float tempArray[] = new float[data.length];
@@ -156,6 +222,14 @@ public class Utilities {
         return peaks;
     }
 
+	/**
+	 * Find the first N peaks in an array
+	 *
+	 * @param data the array
+	 * @param numPeaks the number of peaks to find
+	 *
+	 * @return the first peaks in the array, in the order they appear
+	 */
     public static int[] findOrderedPeaks(float[] data, int numPeaks) {
         int peaks[] = new int[numPeaks];
         Arrays.fill(peaks, 0);
@@ -170,7 +244,12 @@ public class Utilities {
         return peaks;
     }
 
-    public static boolean isAndroid(){
+	/**
+	 * Are we currently running on Android, or regular Java?
+	 *
+	 * @return true if app is running on DVM (Android) and false if running on JVM (Java)
+	 */
+	public static boolean isAndroid(){
         return System.getProperty("java.vendor").equals("The Android Project");
     }
 }


### PR DESCRIPTION
## 1.0.1 - 2018-03-22 
### Added
- A-weighting filter to Filter
- JavaDoc comments to Utilities class
- a changelog

### Changed
- Power and Magnitude calculations in FFT to single sided form, divide by 2 and mirror the array to 
get back to 2 sided versions
- FormantExtractor now takes number of formants to extract as a constructor argument (before it was 
hardcoded to 3, now it will default to 4 if not specified)
- FormantExtractor now ony returns valid formants (frequency > 90 Hz, bandwidth < 400 Hz)
- index.html was changed to add a few small tweaks to the web page

### Fixed 
- MFCC returning NaN's if filter bank was setup with too many filters, or if the minimum frequency 
is set too low.
- fixed an error in Filters recursive filter calculation
- fixed an error in FFT's Power spectrum calculation - previously was dividing by N instead of N^2
